### PR TITLE
Limit notes returned by find tool

### DIFF
--- a/src/anki_mcp/tools/find_notes.py
+++ b/src/anki_mcp/tools/find_notes.py
@@ -3,20 +3,13 @@ from .utils import make_anki_request
 from datetime import datetime
 
 
-def _truncate(value: str, max_length: int = 100) -> str:
-    """Truncate a string to max_length, adding ellipsis if needed."""
-    if len(value) > max_length:
-        return value[:max_length - 3] + "..."
-    return value
-
-
 def _format_note(note: dict) -> str:
     """Format a single note for display."""
     tags = ", ".join(note["tags"]) if note["tags"] else "(no tags)"
     mod_time = datetime.fromtimestamp(note["mod"]).strftime("%Y-%m-%d %H:%M:%S")
 
     fields_text = [
-        f"  - {name}: {_truncate(data['value'])}"
+        f"  - {name}: {data['value']}"
         for name, data in note["fields"].items()
     ]
 

--- a/src/anki_mcp/tools/find_notes.py
+++ b/src/anki_mcp/tools/find_notes.py
@@ -2,12 +2,13 @@ import mcp.types as types
 from .utils import make_anki_request
 from datetime import datetime
 
-async def find_notes(query: str) -> list[types.TextContent]:
+async def find_notes(query: str, limit: int = 20) -> list[types.TextContent]:
     result = await make_anki_request("notesInfo", query=query)
-    
+
     if result["success"]:
         notes = result["result"]
-        
+        total_count = len(notes)
+
         if not notes:
             return [
                 types.TextContent(
@@ -15,9 +16,12 @@ async def find_notes(query: str) -> list[types.TextContent]:
                     text=f"No notes found matching query: '{query}'",
                 )
             ]
-        
+
+        # Apply limit
+        limited_notes = notes[:limit]
+
         notes_info = []
-        for note in notes:
+        for note in limited_notes:
             note_id = note["noteId"]
             model_name = note["modelName"]
             tags = ", ".join(note["tags"]) if note["tags"] else "(no tags)"
@@ -43,10 +47,16 @@ async def find_notes(query: str) -> list[types.TextContent]:
             )
             notes_info.append(note_text)
         
+        # Build header message
+        if total_count > limit:
+            header = f"Showing {len(limited_notes)} of {total_count} notes matching query: '{query}' (use a more specific query or increase limit to see more)"
+        else:
+            header = f"Found {total_count} notes matching query: '{query}'"
+
         return [
             types.TextContent(
                 type="text",
-                text=f"Found {len(notes)} notes matching query: '{query}'\n\n" + "\n\n".join(notes_info),
+                text=header + "\n\n" + "\n\n".join(notes_info),
             )
         ]
     else:

--- a/src/anki_mcp/tools/find_notes.py
+++ b/src/anki_mcp/tools/find_notes.py
@@ -2,67 +2,66 @@ import mcp.types as types
 from .utils import make_anki_request
 from datetime import datetime
 
+
+def _truncate(value: str, max_length: int = 100) -> str:
+    """Truncate a string to max_length, adding ellipsis if needed."""
+    if len(value) > max_length:
+        return value[:max_length - 3] + "..."
+    return value
+
+
+def _format_note(note: dict) -> str:
+    """Format a single note for display."""
+    tags = ", ".join(note["tags"]) if note["tags"] else "(no tags)"
+    mod_time = datetime.fromtimestamp(note["mod"]).strftime("%Y-%m-%d %H:%M:%S")
+
+    fields_text = [
+        f"  - {name}: {_truncate(data['value'])}"
+        for name, data in note["fields"].items()
+    ]
+
+    return (
+        f"Note ID: {note['noteId']}\n"
+        f"Model: {note['modelName']}\n"
+        f"Tags: {tags}\n"
+        f"Modified: {mod_time}\n"
+        f"Fields:\n" + "\n".join(fields_text) + "\n"
+    )
+
+
 async def find_notes(query: str, limit: int = 20) -> list[types.TextContent]:
     result = await make_anki_request("notesInfo", query=query)
 
-    if result["success"]:
-        notes = result["result"]
-        total_count = len(notes)
-
-        if not notes:
-            return [
-                types.TextContent(
-                    type="text",
-                    text=f"No notes found matching query: '{query}'",
-                )
-            ]
-
-        # Apply limit
-        limited_notes = notes[:limit]
-
-        notes_info = []
-        for note in limited_notes:
-            note_id = note["noteId"]
-            model_name = note["modelName"]
-            tags = ", ".join(note["tags"]) if note["tags"] else "(no tags)"
-            
-            # Format fields
-            fields_text = []
-            for field_name, field_data in note["fields"].items():
-                field_value = field_data["value"]
-                # Truncate very long field values for display
-                if len(field_value) > 100:
-                    field_value = field_value[:97] + "..."
-                fields_text.append(f"  - {field_name}: {field_value}")
-            
-            # Format modification time
-            mod_time = datetime.fromtimestamp(note["mod"]).strftime("%Y-%m-%d %H:%M:%S")
-            
-            note_text = (
-                f"Note ID: {note_id}\n"
-                f"Model: {model_name}\n"
-                f"Tags: {tags}\n"
-                f"Modified: {mod_time}\n"
-                f"Fields:\n" + "\n".join(fields_text) + "\n"
-            )
-            notes_info.append(note_text)
-        
-        # Build header message
-        if total_count > limit:
-            header = f"Showing {len(limited_notes)} of {total_count} notes matching query: '{query}' (use a more specific query or increase limit to see more)"
-        else:
-            header = f"Found {total_count} notes matching query: '{query}'"
-
-        return [
-            types.TextContent(
-                type="text",
-                text=header + "\n\n" + "\n\n".join(notes_info),
-            )
-        ]
-    else:
+    if not result["success"]:
         return [
             types.TextContent(
                 type="text",
                 text=f"Failed to retrieve notes: {result['error']}",
             )
         ]
+
+    notes = result["result"]
+
+    if not notes:
+        return [
+            types.TextContent(
+                type="text",
+                text=f"No notes found matching query: '{query}'",
+            )
+        ]
+
+    total_count = len(notes)
+    limited_notes = notes[:limit]
+    notes_info = [_format_note(note) for note in limited_notes]
+
+    if total_count > limit:
+        header = f"Showing {len(limited_notes)} of {total_count} notes matching query: '{query}' (use a more specific query or increase limit to see more)"
+    else:
+        header = f"Found {total_count} notes matching query: '{query}'"
+
+    return [
+        types.TextContent(
+            type="text",
+            text=header + "\n\n" + "\n\n".join(notes_info),
+        )
+    ]

--- a/tests/test_find_notes.py
+++ b/tests/test_find_notes.py
@@ -79,8 +79,8 @@ async def test_find_notes_api_failure(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_find_notes_long_field_truncation(monkeypatch):
-    """Test that long field values are truncated at 100 characters."""
+async def test_find_notes_long_field_shown_in_full(monkeypatch):
+    """Test that long field values are shown in full."""
     long_value = "A" * 150  # 150 characters
     mock_notes = [
         {
@@ -103,9 +103,8 @@ async def test_find_notes_long_field_truncation(monkeypatch):
     result = await find_notes("*")
 
     text = result[0].text
-    # Should be truncated to 97 chars + "..."
-    assert "A" * 97 + "..." in text
-    assert "A" * 100 not in text
+    # Full value should be present
+    assert long_value in text
 
 
 @pytest.mark.asyncio

--- a/tests/test_find_notes.py
+++ b/tests/test_find_notes.py
@@ -151,3 +151,100 @@ async def test_find_notes_special_characters_in_query(monkeypatch):
 
     assert len(result) == 1
     assert "No notes found" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_find_notes_limit_results(monkeypatch):
+    """Test that results are limited when exceeding the limit parameter."""
+    # Create 30 mock notes
+    mock_notes = [
+        {
+            "noteId": i,
+            "modelName": "Basic",
+            "tags": [],
+            "fields": {
+                "Front": {"value": f"Question {i}", "order": 0},
+                "Back": {"value": f"Answer {i}", "order": 1}
+            },
+            "mod": 1700000000 + i
+        }
+        for i in range(30)
+    ]
+
+    async def mock_anki_request(action, **kwargs):
+        return {"success": True, "result": mock_notes}
+
+    monkeypatch.setattr("anki_mcp.tools.find_notes.make_anki_request", mock_anki_request)
+
+    # Test with default limit (20)
+    result = await find_notes("deck:Test")
+
+    text = result[0].text
+    assert "Showing 20 of 30 notes" in text
+    assert "use a more specific query or increase limit to see more" in text
+    # Should have notes 0-19 but not 20+
+    assert "Note ID: 0" in text
+    assert "Note ID: 19" in text
+    assert "Note ID: 20" not in text
+
+
+@pytest.mark.asyncio
+async def test_find_notes_custom_limit(monkeypatch):
+    """Test that custom limit parameter works."""
+    mock_notes = [
+        {
+            "noteId": i,
+            "modelName": "Basic",
+            "tags": [],
+            "fields": {
+                "Front": {"value": f"Question {i}", "order": 0},
+                "Back": {"value": f"Answer {i}", "order": 1}
+            },
+            "mod": 1700000000 + i
+        }
+        for i in range(10)
+    ]
+
+    async def mock_anki_request(action, **kwargs):
+        return {"success": True, "result": mock_notes}
+
+    monkeypatch.setattr("anki_mcp.tools.find_notes.make_anki_request", mock_anki_request)
+
+    # Test with custom limit of 5
+    result = await find_notes("deck:Test", limit=5)
+
+    text = result[0].text
+    assert "Showing 5 of 10 notes" in text
+    assert "Note ID: 0" in text
+    assert "Note ID: 4" in text
+    assert "Note ID: 5" not in text
+
+
+@pytest.mark.asyncio
+async def test_find_notes_under_limit(monkeypatch):
+    """Test that no truncation message appears when results are under limit."""
+    mock_notes = [
+        {
+            "noteId": i,
+            "modelName": "Basic",
+            "tags": [],
+            "fields": {
+                "Front": {"value": f"Question {i}", "order": 0},
+                "Back": {"value": f"Answer {i}", "order": 1}
+            },
+            "mod": 1700000000 + i
+        }
+        for i in range(5)
+    ]
+
+    async def mock_anki_request(action, **kwargs):
+        return {"success": True, "result": mock_notes}
+
+    monkeypatch.setattr("anki_mcp.tools.find_notes.make_anki_request", mock_anki_request)
+
+    result = await find_notes("deck:Test", limit=10)
+
+    text = result[0].text
+    assert "Found 5 notes matching query: 'deck:Test'" in text
+    assert "Showing" not in text
+    assert "increase limit" not in text


### PR DESCRIPTION
Add a limit parameter (default 20) to the find_notes tool to prevent large query results from filling up the model's context. When results exceed the limit, shows "Showing X of Y notes" with a hint to refine the query or increase the limit.