### PR TITLE
feat(tools): add suspend and unsuspend cards tools

### DIFF
--- a/src/anki_mcp/server.py
+++ b/src/anki_mcp/server.py
@@ -5,6 +5,7 @@ from anki_mcp.tools.get_collection_overview import get_collection_overview
 from anki_mcp.tools.add_or_update_notes import add_or_update_notes
 from anki_mcp.tools.get_review_stats import get_review_stats
 from anki_mcp.tools.find_notes import find_notes
+from anki_mcp.tools.suspend_cards import suspend_cards, unsuspend_cards
 
 app = FastMCP("anki")
 
@@ -13,6 +14,8 @@ app.tool(name="get-collection-overview", description="Get comprehensive informat
 app.tool(name="get-review-stats", description="Get review statistics from Anki showing cards reviewed per day, with optional time range filtering")(get_review_stats)
 app.tool(name='find-notes', description='Find notes matching a query in Anki')(find_notes)
 app.tool(name='add-or-update-notes', description="Add new notes or update existing ones in Anki")(add_or_update_notes)
+app.tool(name='suspend-cards', description="Suspend cards by their card IDs")(suspend_cards)
+app.tool(name='unsuspend-cards', description="Unsuspend cards by their card IDs")(unsuspend_cards)
 
 if __name__ == "__main__":
     # Initialize and run the server

--- a/src/anki_mcp/server.py
+++ b/src/anki_mcp/server.py
@@ -5,6 +5,7 @@ from anki_mcp.tools.get_collection_overview import get_collection_overview
 from anki_mcp.tools.add_or_update_notes import add_or_update_notes
 from anki_mcp.tools.get_review_stats import get_review_stats
 from anki_mcp.tools.find_notes import find_notes
+from anki_mcp.tools.find_cards import find_cards
 from anki_mcp.tools.suspend_cards import suspend_cards, unsuspend_cards
 
 app = FastMCP("anki")
@@ -13,6 +14,7 @@ app = FastMCP("anki")
 app.tool(name="get-collection-overview", description="Get comprehensive information about the Anki collection including decks, models, and fields")(get_collection_overview)
 app.tool(name="get-review-stats", description="Get review statistics from Anki showing cards reviewed per day, with optional time range filtering")(get_review_stats)
 app.tool(name='find-notes', description='Find notes matching a query in Anki')(find_notes)
+app.tool(name='find-cards', description='Find card IDs matching a query in Anki')(find_cards)
 app.tool(name='add-or-update-notes', description="Add new notes or update existing ones in Anki")(add_or_update_notes)
 app.tool(name='suspend-cards', description="Suspend cards by their card IDs")(suspend_cards)
 app.tool(name='unsuspend-cards', description="Unsuspend cards by their card IDs")(unsuspend_cards)

--- a/src/anki_mcp/tools/find_cards.py
+++ b/src/anki_mcp/tools/find_cards.py
@@ -1,0 +1,50 @@
+import mcp.types as types
+from .utils import make_anki_request
+
+
+async def find_cards(query: str, limit: int = 100) -> list[types.TextContent]:
+    """Find cards matching a query in Anki.
+
+    Args:
+        query: Anki search query (e.g., "deck:Default", "is:suspended").
+        limit: Maximum number of card IDs to return (default 100).
+
+    Returns:
+        TextContent with matching card IDs.
+    """
+    result = await make_anki_request("findCards", query=query)
+
+    if not result["success"]:
+        return [
+            types.TextContent(
+                type="text",
+                text=f"Failed to find cards: {result['error']}",
+            )
+        ]
+
+    card_ids = result["result"]
+
+    if not card_ids:
+        return [
+            types.TextContent(
+                type="text",
+                text=f"No cards found matching query: '{query}'",
+            )
+        ]
+
+    total_count = len(card_ids)
+    limited_ids = card_ids[:limit]
+
+    if total_count > limit:
+        header = f"Showing {len(limited_ids)} of {total_count} card IDs matching query: '{query}' (use a more specific query or increase limit to see more)"
+    else:
+        header = f"Found {total_count} card(s) matching query: '{query}'"
+
+    card_ids_text = "\n".join(str(cid) for cid in limited_ids)
+
+    return [
+        types.TextContent(
+            type="text",
+            text=f"{header}\n\nCard IDs:\n{card_ids_text}",
+        )
+    ]

--- a/src/anki_mcp/tools/suspend_cards.py
+++ b/src/anki_mcp/tools/suspend_cards.py
@@ -1,0 +1,88 @@
+import mcp.types as types
+from .utils import make_anki_request
+
+
+async def suspend_cards(card_ids: list[int]) -> list[types.TextContent]:
+    """Suspend cards by their card IDs.
+
+    Args:
+        card_ids: List of card IDs to suspend.
+
+    Returns:
+        TextContent indicating success or failure.
+    """
+    if not card_ids:
+        return [
+            types.TextContent(
+                type="text",
+                text="No card IDs provided. Please specify at least one card ID to suspend.",
+            )
+        ]
+
+    result = await make_anki_request("suspend", cards=card_ids)
+
+    if not result["success"]:
+        return [
+            types.TextContent(
+                type="text",
+                text=f"Failed to suspend cards: {result['error']}",
+            )
+        ]
+
+    if result["result"]:
+        return [
+            types.TextContent(
+                type="text",
+                text=f"Successfully suspended {len(card_ids)} card(s).",
+            )
+        ]
+    else:
+        return [
+            types.TextContent(
+                type="text",
+                text="No cards were suspended (all cards were already suspended).",
+            )
+        ]
+
+
+async def unsuspend_cards(card_ids: list[int]) -> list[types.TextContent]:
+    """Unsuspend cards by their card IDs.
+
+    Args:
+        card_ids: List of card IDs to unsuspend.
+
+    Returns:
+        TextContent indicating success or failure.
+    """
+    if not card_ids:
+        return [
+            types.TextContent(
+                type="text",
+                text="No card IDs provided. Please specify at least one card ID to unsuspend.",
+            )
+        ]
+
+    result = await make_anki_request("unsuspend", cards=card_ids)
+
+    if not result["success"]:
+        return [
+            types.TextContent(
+                type="text",
+                text=f"Failed to unsuspend cards: {result['error']}",
+            )
+        ]
+
+    if result["result"]:
+        return [
+            types.TextContent(
+                type="text",
+                text=f"Successfully unsuspended {len(card_ids)} card(s).",
+            )
+        ]
+    else:
+        return [
+            types.TextContent(
+                type="text",
+                text="No cards were unsuspended (no cards were previously suspended).",
+            )
+        ]

--- a/tests/test_find_cards.py
+++ b/tests/test_find_cards.py
@@ -1,0 +1,145 @@
+import pytest
+from anki_mcp.tools.find_cards import find_cards
+
+
+@pytest.mark.asyncio
+async def test_find_cards_success(monkeypatch):
+    """Test successful card search with multiple results."""
+    mock_card_ids = [1494723142483, 1494703460437, 1494703479525]
+
+    async def mock_anki_request(action, **kwargs):
+        assert action == "findCards"
+        assert kwargs["query"] == "deck:Test"
+        return {"success": True, "result": mock_card_ids}
+
+    monkeypatch.setattr("anki_mcp.tools.find_cards.make_anki_request", mock_anki_request)
+
+    result = await find_cards("deck:Test")
+
+    assert len(result) == 1
+    text = result[0].text
+    assert "Found 3 card(s) matching query: 'deck:Test'" in text
+    assert "1494723142483" in text
+    assert "1494703460437" in text
+    assert "1494703479525" in text
+
+
+@pytest.mark.asyncio
+async def test_find_cards_no_results(monkeypatch):
+    """Test search that returns no matching cards."""
+    async def mock_anki_request(action, **kwargs):
+        assert action == "findCards"
+        return {"success": True, "result": []}
+
+    monkeypatch.setattr("anki_mcp.tools.find_cards.make_anki_request", mock_anki_request)
+
+    result = await find_cards("deck:NonExistent")
+
+    assert len(result) == 1
+    assert "No cards found matching query: 'deck:NonExistent'" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_find_cards_api_failure(monkeypatch):
+    """Test handling of API errors."""
+    async def mock_anki_request(action, **kwargs):
+        return {"success": False, "error": "Invalid search query"}
+
+    monkeypatch.setattr("anki_mcp.tools.find_cards.make_anki_request", mock_anki_request)
+
+    result = await find_cards("invalid:query")
+
+    assert len(result) == 1
+    assert "Failed to find cards: Invalid search query" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_find_cards_single_result(monkeypatch):
+    """Test search returning a single card."""
+    async def mock_anki_request(action, **kwargs):
+        return {"success": True, "result": [1234567890123]}
+
+    monkeypatch.setattr("anki_mcp.tools.find_cards.make_anki_request", mock_anki_request)
+
+    result = await find_cards("is:suspended")
+
+    assert len(result) == 1
+    text = result[0].text
+    assert "Found 1 card(s) matching query: 'is:suspended'" in text
+    assert "1234567890123" in text
+
+
+@pytest.mark.asyncio
+async def test_find_cards_limit_results(monkeypatch):
+    """Test that results are limited when exceeding the limit parameter."""
+    # Create 150 mock card IDs
+    mock_card_ids = list(range(1000000000000, 1000000000150))
+
+    async def mock_anki_request(action, **kwargs):
+        return {"success": True, "result": mock_card_ids}
+
+    monkeypatch.setattr("anki_mcp.tools.find_cards.make_anki_request", mock_anki_request)
+
+    # Test with default limit (100)
+    result = await find_cards("deck:Test")
+
+    text = result[0].text
+    assert "Showing 100 of 150 card IDs" in text
+    assert "use a more specific query or increase limit to see more" in text
+    # Should have first 100 IDs but not the rest
+    assert "1000000000000" in text
+    assert "1000000000099" in text
+    assert "1000000000100" not in text
+
+
+@pytest.mark.asyncio
+async def test_find_cards_custom_limit(monkeypatch):
+    """Test that custom limit parameter works."""
+    mock_card_ids = list(range(1000000000000, 1000000000050))
+
+    async def mock_anki_request(action, **kwargs):
+        return {"success": True, "result": mock_card_ids}
+
+    monkeypatch.setattr("anki_mcp.tools.find_cards.make_anki_request", mock_anki_request)
+
+    # Test with custom limit of 10
+    result = await find_cards("deck:Test", limit=10)
+
+    text = result[0].text
+    assert "Showing 10 of 50 card IDs" in text
+    assert "1000000000000" in text
+    assert "1000000000009" in text
+    assert "1000000000010" not in text
+
+
+@pytest.mark.asyncio
+async def test_find_cards_under_limit(monkeypatch):
+    """Test that no truncation message appears when results are under limit."""
+    mock_card_ids = [1234, 5678, 9012]
+
+    async def mock_anki_request(action, **kwargs):
+        return {"success": True, "result": mock_card_ids}
+
+    monkeypatch.setattr("anki_mcp.tools.find_cards.make_anki_request", mock_anki_request)
+
+    result = await find_cards("deck:Test", limit=10)
+
+    text = result[0].text
+    assert "Found 3 card(s) matching query: 'deck:Test'" in text
+    assert "Showing" not in text
+    assert "increase limit" not in text
+
+
+@pytest.mark.asyncio
+async def test_find_cards_special_characters_in_query(monkeypatch):
+    """Test search with special characters in query."""
+    async def mock_anki_request(action, **kwargs):
+        assert kwargs["query"] == "is:suspended deck:\"My Deck\""
+        return {"success": True, "result": []}
+
+    monkeypatch.setattr("anki_mcp.tools.find_cards.make_anki_request", mock_anki_request)
+
+    result = await find_cards("is:suspended deck:\"My Deck\"")
+
+    assert len(result) == 1
+    assert "No cards found" in result[0].text

--- a/tests/test_suspend_cards.py
+++ b/tests/test_suspend_cards.py
@@ -1,0 +1,144 @@
+import pytest
+from anki_mcp.tools.suspend_cards import suspend_cards, unsuspend_cards
+
+
+@pytest.mark.asyncio
+async def test_suspend_cards_success(monkeypatch):
+    """Test successful card suspension."""
+    async def mock_anki_request(action, **kwargs):
+        assert action == "suspend"
+        assert kwargs["cards"] == [1234, 5678]
+        return {"success": True, "result": True}
+
+    monkeypatch.setattr("anki_mcp.tools.suspend_cards.make_anki_request", mock_anki_request)
+
+    result = await suspend_cards([1234, 5678])
+
+    assert len(result) == 1
+    assert "Successfully suspended 2 card(s)" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_suspend_cards_already_suspended(monkeypatch):
+    """Test suspending cards that are already suspended."""
+    async def mock_anki_request(action, **kwargs):
+        assert action == "suspend"
+        return {"success": True, "result": False}
+
+    monkeypatch.setattr("anki_mcp.tools.suspend_cards.make_anki_request", mock_anki_request)
+
+    result = await suspend_cards([1234])
+
+    assert len(result) == 1
+    assert "No cards were suspended" in result[0].text
+    assert "already suspended" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_suspend_cards_api_failure(monkeypatch):
+    """Test handling of API errors during suspension."""
+    async def mock_anki_request(action, **kwargs):
+        return {"success": False, "error": "Card not found"}
+
+    monkeypatch.setattr("anki_mcp.tools.suspend_cards.make_anki_request", mock_anki_request)
+
+    result = await suspend_cards([9999])
+
+    assert len(result) == 1
+    assert "Failed to suspend cards: Card not found" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_suspend_cards_empty_list():
+    """Test suspending with empty card list."""
+    result = await suspend_cards([])
+
+    assert len(result) == 1
+    assert "No card IDs provided" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_suspend_cards_single_card(monkeypatch):
+    """Test suspending a single card."""
+    async def mock_anki_request(action, **kwargs):
+        assert action == "suspend"
+        assert kwargs["cards"] == [1234]
+        return {"success": True, "result": True}
+
+    monkeypatch.setattr("anki_mcp.tools.suspend_cards.make_anki_request", mock_anki_request)
+
+    result = await suspend_cards([1234])
+
+    assert len(result) == 1
+    assert "Successfully suspended 1 card(s)" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_unsuspend_cards_success(monkeypatch):
+    """Test successful card unsuspension."""
+    async def mock_anki_request(action, **kwargs):
+        assert action == "unsuspend"
+        assert kwargs["cards"] == [1234, 5678]
+        return {"success": True, "result": True}
+
+    monkeypatch.setattr("anki_mcp.tools.suspend_cards.make_anki_request", mock_anki_request)
+
+    result = await unsuspend_cards([1234, 5678])
+
+    assert len(result) == 1
+    assert "Successfully unsuspended 2 card(s)" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_unsuspend_cards_not_suspended(monkeypatch):
+    """Test unsuspending cards that were not suspended."""
+    async def mock_anki_request(action, **kwargs):
+        assert action == "unsuspend"
+        return {"success": True, "result": False}
+
+    monkeypatch.setattr("anki_mcp.tools.suspend_cards.make_anki_request", mock_anki_request)
+
+    result = await unsuspend_cards([1234])
+
+    assert len(result) == 1
+    assert "No cards were unsuspended" in result[0].text
+    assert "no cards were previously suspended" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_unsuspend_cards_api_failure(monkeypatch):
+    """Test handling of API errors during unsuspension."""
+    async def mock_anki_request(action, **kwargs):
+        return {"success": False, "error": "Card not found"}
+
+    monkeypatch.setattr("anki_mcp.tools.suspend_cards.make_anki_request", mock_anki_request)
+
+    result = await unsuspend_cards([9999])
+
+    assert len(result) == 1
+    assert "Failed to unsuspend cards: Card not found" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_unsuspend_cards_empty_list():
+    """Test unsuspending with empty card list."""
+    result = await unsuspend_cards([])
+
+    assert len(result) == 1
+    assert "No card IDs provided" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_unsuspend_cards_single_card(monkeypatch):
+    """Test unsuspending a single card."""
+    async def mock_anki_request(action, **kwargs):
+        assert action == "unsuspend"
+        assert kwargs["cards"] == [1234]
+        return {"success": True, "result": True}
+
+    monkeypatch.setattr("anki_mcp.tools.suspend_cards.make_anki_request", mock_anki_request)
+
+    result = await unsuspend_cards([1234])
+
+    assert len(result) == 1
+    assert "Successfully unsuspended 1 card(s)" in result[0].text


### PR DESCRIPTION
Add two new MCP tools for suspending and unsuspending Anki cards:
- suspend-cards: Suspend cards by their card IDs
- unsuspend-cards: Unsuspend cards by their card IDs

Both tools use the AnkiConnect suspend/unsuspend actions and include proper error handling for API failures and edge cases like empty lists.